### PR TITLE
Add support for PTT links

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Fixings are currently available for:
 - Bilibili: [fxbilibili](https://github.com/seriaati/fxbilibili)/[EmbedEZ](https://github.com/seriaati/embedez)/[BiliFix](https://vxbilibili.com)
 - Tumblr: [fxtumblr](https://github.com/knuxify/fxtumblr)
 - Threads: [FixThreads](https://github.com/milanmdev/fixthreads)/[vxThreads](https://github.com/everettsouthwick/vxThreads)
+- PTT: Extracts supported links inside the post
 
 If your message contains link(s) that are of any of the social medias above, it gets deleted and resent using a webhook with your name and avatar containing the fix. There is also a ❌ reaction made to the message, so that the author of the message can click on and delete the message. The emoji used can be changed with the `/settings` command.
 

--- a/embed_fixer/cogs/fixer.py
+++ b/embed_fixer/cogs/fixer.py
@@ -145,7 +145,7 @@ class FixerCog(commands.Cog):
             break
         return domain, website
 
-    async def _find_fixes(  # noqa: PLR0912, PLR0914
+    async def _find_fixes(  # noqa: PLR0912, PLR0914, PLR0915
         self,
         message: discord.Message,
         *,
@@ -166,12 +166,23 @@ class FixerCog(commands.Cog):
             isinstance(message.channel, discord.TextChannel) and message.channel.nsfw
         )
         urls = extract_urls(message.content)
-
-        for url, spoilered in urls:
+        i = 0
+        while i < len(urls):
+            url, spoilered = urls[i]
+            i += 1
             clean_url = remove_query_params(url).replace("www.", "")
             domain, website = self._get_matching_domain_website(settings, clean_url)
 
             if domain is None or website is None:
+                continue
+
+            if domain.id == DomainId.PTT:
+                try:
+                    extracted = await self.fetch_info.ptt(url)
+                except Exception:
+                    logger.exception(f"Failed to fetch PTT page {url}")
+                    continue
+                urls.extend((u, spoilered) for u in extracted)
                 continue
 
             pixiv_skip = (

--- a/embed_fixer/fixes.py
+++ b/embed_fixer/fixes.py
@@ -21,6 +21,7 @@ class DomainId(IntEnum):
     BILIBILI = 12
     TUMBLR = 13
     THREADS = 14
+    PTT = 15
 
 
 @dataclass(kw_only=True)
@@ -397,5 +398,11 @@ DOMAINS: Final[list[Domain]] = [
                 repo_url="https://github.com/everettsouthwick/vxThreads",
             ),
         ],
+    ),
+    Domain(
+        id=DomainId.PTT,
+        name="PTT",
+        websites=[Website(r"https://(www\.)?ptt\.cc/bbs/\w+/[\w.]+\.html")],
+        fix_methods=[],
     ),
 ]

--- a/embed_fixer/utils/fetch_info.py
+++ b/embed_fixer/utils/fetch_info.py
@@ -8,7 +8,7 @@ from dotenv import load_dotenv
 from loguru import logger
 from pydantic import BaseModel, Field, field_validator
 
-from embed_fixer.utils.misc import remove_html_tags, replace_domain
+from embed_fixer.utils.misc import extract_urls, remove_html_tags, replace_domain
 
 if TYPE_CHECKING:
     import aiohttp
@@ -155,6 +155,16 @@ class PostInfoFetcher:
             return []
 
         return [f"https://fxbilibili.seria.moe/dl/{bvid}"]
+
+    async def ptt(self, url: str) -> list[str]:
+        cookies = {"over18": "1"}
+        async with self.session.get(url, cookies=cookies) as resp:
+            if resp.status != 200:
+                return []
+            text = await resp.text()
+
+        text = remove_html_tags(text)
+        return [u for u, _ in extract_urls(text)]
 
 
 class PixivArtwork(BaseModel):


### PR DESCRIPTION
## Summary
- support ptt.cc links to discover supported URLs inside posts
- recognize PTT domain
- handle `over18` confirmation automatically
- document PTT support

## Testing
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_684d6698eea883299165da664a03fb09